### PR TITLE
Fix small typos in readme.md FAQ

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ FAQ
 
 **How should use this library?**
 
-Everybody that wants to add the @examples syntax to there testing workflow or tool should have a look. If you would like to discuss the integration into your tool, please feel free to contact me. 
+Everybody that wants to add the @examples syntax to their testing workflow or tool should have a look. If you would like to discuss the integration into your tool, please feel free to contact me. 
 
 **Does this generate JSDoc project documentation?**
 
@@ -73,6 +73,6 @@ No it does not. For this use e.g. [grunt-jsdoc](https://github.com/krampstudio/g
 
 **This looks a lot like [autodoc](https://github.com/dtao/autodoc). Why not just use autodoc or fork it?**
 
-I really liked the idea of autodoc, but not that test runs are mixed into the documentation. Also in my opinion the goal to be a full blown JSDoc suit adds a lot of unnecessary weight and clutter. So this project treats @examples tests like real tests and a seperate JSDoc parser can be used to generate the documentation. 
+I really liked the idea of autodoc, but not that test runs are mixed into the documentation. Also in my opinion the goal to be a full blown JSDoc suit adds a lot of unnecessary weight and clutter. So this project treats @examples tests like real tests and a separate JSDoc parser can be used to generate the documentation. 
 
 


### PR DESCRIPTION
Just changed "there" to "their" and "seperate" to "separate".
